### PR TITLE
Remove implicit folder structure from config

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function run(configFile) {
 		outputFolder = '',
 		baseFolder = process.cwd() + '/';
 
-	var config = require(baseFolder + 'config/' + configFile + '.json');
+	var config = require(baseFolder + configFile);
 
 	outputFolder = typeof config.outputDir === 'undefined' ? baseFolder + 'shots/' : baseFolder + 'shots/' + config.outputDir;
 

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,13 @@ Based on the Ruby version available at [http://github.com/BBC-News/wraith](http:
 	--v, --version	Output version information
 
 	Examples:
-	wraith --config chrome
+	wraith --config ./config/chrome.json
 
 ### Configuration file
 
-Wraith uses a json based configuration file that allows you specfify a large number of options. You can create as many configurations files as you need and call them from the cli using the --config flag. All congiguration files must be stored within the config folder.
+Wraith uses a json based configuration file that allows you specfify a large number of options. You can create as many configurations files as you need and call them from the cli using the --config flag. These configuration files can live anywhere that is addressable by a local path and they are passed as an argument like this:
+
+    wraith --config ./path/to/my_config.json
 
 Below is an example configuration file:
 


### PR DESCRIPTION
Remove the need for an implicit config folder structure (which is badly documented, in the original Wraith Ruby project as well).

Now you pass a full relative path e.g. `./config/my_config.json` or `./my/other/folder/my_config.json`. Which allows for much saner configuration of projects, meaning users don't have to create arbitrary directories for just a wraith config file or messing with their nicely organised existing config directories by putting a json file at the top level.

I realise this is a divergence from the 'upstream' Wriath config, but in this case I think it's an improvement!