### PR TITLE
feat: add option renderDelay

### DIFF
--- a/lib/wraith.js
+++ b/lib/wraith.js
@@ -47,6 +47,7 @@ Wraith.prototype.config = function(config) {
 	self.outputFolder   = config.outputDir || 'shots/';
 	self.engines        = config.engines || ['phantomjs'];
 	self.maxConnections = config.maxConnections || 20;
+	self.renderDelay    = config.renderDelay || 0;
 	self.project        = config.project || '';
 	self.sizes          = [];
 	self.dirs           = [];
@@ -188,6 +189,7 @@ Wraith.prototype.takeScreenshots = function () {
 				width:  task.size,
 				height: 'all'
 			},
+			renderDelay: self.renderDelay,
 			defaultWhiteBackground: true,
 			phantomPath: self.getEnginePath[task.engine],
 			phantomConfig: {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "progress": "^1.1.8",
     "rimraf": "~2.2.6",
     "w3counter": "^1.0.3",
-    "webshot": "^0.15.3",
+    "webshot": "^0.18.0",
     "connect": "^3.3.5",
     "open": "^0.0.5",
     "serve-static": "^1.9.3"

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,9 @@ Below is an example configuration file:
 
 		Limit the amount of concurrent processes
 		"maxConnections": 20
+
+		Number of milliseconds to wait after a page loads before taking the screenshot.
+		"renderDelay": 0
 	}
 
 ###API


### PR DESCRIPTION
This introduces the new option `renderDelay` that gets passed to webshot. The default `renderDelay` is still 0ms. This forces webshot to wait some milliseconds before rendering the screenshot. This is useful is complicated scripts need to be executed first.

I also updated webshot to a higher (compatible) version.

All changes are compatible to existing configs. Therefore I recommend a minor version change.