### PR TITLE
feat: new option to turn gallery generation off

### DIFF
--- a/lib/wraith.js
+++ b/lib/wraith.js
@@ -51,6 +51,7 @@ Wraith.prototype.config = function(config) {
 	self.sizes          = [];
 	self.dirs           = [];
 	self.quiet          = config.quiet || false;
+	self.gallery        = config.hasOwnProperty('gallery') ? config.gallery : true;
 	self.server         = {};
 	self.server.start   = config.server.start || false;
 	self.server.port    = config.server.port || 9090;
@@ -293,7 +294,13 @@ Wraith.prototype.compareScreenshots = function() {
 			return self;
 		} else {
 			log.success('Image comparison done');
-			self.generateGallery();
+			if (self.gallery || self.server.start) {
+				self.generateGallery();
+			} else {
+				helpers.emptyFolder(self.outputFolder, function() {
+					self.cb();
+				});
+			}
 			return self;
 		}
 	});
@@ -301,5 +308,12 @@ Wraith.prototype.compareScreenshots = function() {
 
 Wraith.prototype.generateGallery = function() {
 	var self = this;
-	gallery.generate(self.dirs, self.compareQueue, self.outputFolder, self.config.project, self.server, self.cb);
+	gallery.generate(
+		self.dirs,
+		self.compareQueue,
+		self.outputFolder,
+		self.config.project,
+		self.server,
+		self.cb
+	);
 };

--- a/lib/wraith.js
+++ b/lib/wraith.js
@@ -240,6 +240,7 @@ Wraith.prototype.compareScreenshots = function() {
 	}
 
 	self.compareQueue = [];
+	self.maxMismatch = 0;
 
 	for(var url in self.urls) {
 		var dir = self.urls[url].substring(1).replace(/\/+$/,'') + '/';
@@ -278,6 +279,7 @@ Wraith.prototype.compareScreenshots = function() {
 	async.eachLimit(self.compareQueue, self.maxConnections, function(task, callback) {
 		resemble('./' + task.base).compareTo('./' + task.compare).ignoreAntialiasing().onComplete(function(data) {
 			data.getDiffImage().pack().pipe(fs.createWriteStream(task.output));
+			self.maxMismatch = data.misMatchPercentage > self.maxMismatch ? data.misMatchPercentage : self.maxMismatch;
 			fs.writeFile('./' + task.diff, data.misMatchPercentage, function(err) {
 				if(err) { log.error(err); }
 				if(bar) {
@@ -298,7 +300,7 @@ Wraith.prototype.compareScreenshots = function() {
 				self.generateGallery();
 			} else {
 				helpers.emptyFolder(self.outputFolder, function() {
-					self.cb();
+					self.cb(self.maxMismatch);
 				});
 			}
 			return self;
@@ -308,12 +310,5 @@ Wraith.prototype.compareScreenshots = function() {
 
 Wraith.prototype.generateGallery = function() {
 	var self = this;
-	gallery.generate(
-		self.dirs,
-		self.compareQueue,
-		self.outputFolder,
-		self.config.project,
-		self.server,
-		self.cb
-	);
+	gallery.generate(self.dirs, self.compareQueue, self.outputFolder, self.config.project, self.server, self.cb);
 };


### PR DESCRIPTION
This introduces a new option `gallery` which is `true` by default. 
If `gallery` is set to `false` and `server.start` is also `false` then the `outputFolder` gets removed completely (clean) after the compare.

Also the callback now returns the highest mismatch percentage found. This is useful if you want to run wraith quiet inside automated tests. e.g.:

```js
config.quiet = true;
config.gallery = false;
new Wraith(config, function(maxMissmatch) {
  assert.equal(maxMissmatch, 0);
});
```

All changes are compatible to existing configs. Therefore I recommend a minor version change.